### PR TITLE
Add HasLink instance.

### DIFF
--- a/src/Servant/Multipart.hs
+++ b/src/Servant/Multipart.hs
@@ -362,3 +362,7 @@ instance {-# OVERLAPPABLE #-}
 instance {-# OVERLAPPING #-}
          LookupContext cs a => LookupContext (a ': cs) a where
   lookupContext _ (c :. _) = Just c
+
+instance HasLink sub => HasLink (MultipartForm a :> sub) where
+  type MkLink (MultipartForm a :> sub) = MkLink sub
+  toLink _ = toLink (Proxy :: Proxy sub)


### PR DESCRIPTION
Generate link with `toLink` ignoring `MultipartForm`.