### PR TITLE
Implement HasForeign instance

### DIFF
--- a/servant-multipart.cabal
+++ b/servant-multipart.cabal
@@ -41,7 +41,7 @@ library
                 transformers >=0.3 && <0.6,
                 wai >= 3.2 && <3.3,
                 wai-extra >=3.0 && <3.1,
-                servant-foreign >= 0.11.2
+                servant-foreign
   default-language:    Haskell2010
 
 executable upload

--- a/servant-multipart.cabal
+++ b/servant-multipart.cabal
@@ -40,7 +40,8 @@ library
                 text >=1.2 && <1.3,
                 transformers >=0.3 && <0.6,
                 wai >= 3.2 && <3.3,
-                wai-extra >=3.0 && <3.1
+                wai-extra >=3.0 && <3.1,
+                servant-foreign >= 0.11.2
   default-language:    Haskell2010
 
 executable upload

--- a/src/Servant/Multipart.hs
+++ b/src/Servant/Multipart.hs
@@ -535,6 +535,6 @@ instance (HasForeignType lang ftype a, HasForeign lang ftype api)
   foreignFor lang ftype Proxy req =
     foreignFor lang ftype (Proxy @api) $
       req & reqBody .~ Just t
-          & reqBodyIsJSON .~ False
+          & reqBodyContentType .~ ReqBodyMultipart
     where
       t = typeFor lang ftype (Proxy @a)


### PR DESCRIPTION
This is three patches, to `servant-foreign`, `servant-multipart`, and `servant-js`.

https://github.com/haskell-servant/servant-multipart/compare/master...afcady:multipart-foreign?expand=1

https://github.com/haskell-servant/servant/compare/master...afcady:multipart-foreign?expand=1

https://github.com/haskell-servant/servant-js/compare/master...afcady:multipart-foreign?expand=1

The patch to `servant-foreign` adds a Boolean field to the `Req` type specifying whether the request body is JSON (as is currently assumed).  The patch to `servant-multipart` implements a HasForeign instance that sets this field to `False`.  The patch to `servant-js` changes the output of `vanillaJS` when the flag is false, so that `JSON.stringify()` does not get called on the body and the content-type is not set to JSON.

This address https://github.com/haskell-servant/servant-multipart/issues/5