### PR TITLE
Update resolver in stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-9.6
+resolver: lts-13.17
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
Resolver was outdated and thus the project could not be built with
`stack build`. Now it matches the current packages version bounds
specified in cabal project config.