### PR TITLE
Update bounds for random

### DIFF
--- a/servant-multipart.cabal
+++ b/servant-multipart.cabal
@@ -32,7 +32,7 @@ library
     , directory     >=1.3      && <1.4
     , text          >=1.2.3.0  && <1.3
     , transformers  >=0.5.2.0  && <0.6
-    , random        >=0.1.1    && <1.2
+    , random        >=0.1.1    && <1.3
 
   -- other dependencies
   build-depends:


### PR DESCRIPTION
This PR updates bounds for random-1.2 which was released about a year ago.

If possible a new revision on hackage would be awesome, since it is blocking commercialhaskell/stackage#5474