### PR TITLE
Allow lens-5.1, text-2.0

### DIFF
--- a/servant-multipart-api/servant-multipart-api.cabal
+++ b/servant-multipart-api/servant-multipart-api.cabal
@@ -30,7 +30,7 @@ library
   build-depends:
       base          >=4.9      && <5
     , bytestring    >=0.10.8.1 && <0.11
-    , text          >=1.2.3.0  && <1.3
+    , text          >=1.2.3.0  && <2.1
     , transformers  >=0.5.2.0  && <0.6
 
   -- other dependencies

--- a/servant-multipart-client/servant-multipart-client.cabal
+++ b/servant-multipart-client/servant-multipart-client.cabal
@@ -30,7 +30,7 @@ library
       array         >=0.5.1.1  && <0.6
     , base          >=4.9      && <5
     , bytestring    >=0.10.8.1 && <0.11
-    , text          >=1.2.3.0  && <1.3
+    , text          >=1.2.3.0  && <2.1
     , random        >=0.1.1    && <1.3
 
   -- other dependencies

--- a/servant-multipart/servant-multipart.cabal
+++ b/servant-multipart/servant-multipart.cabal
@@ -30,12 +30,12 @@ library
       base          >=4.9      && <5
     , bytestring    >=0.10.8.1 && <0.11
     , directory     >=1.3      && <1.4
-    , text          >=1.2.3.0  && <1.3
+    , text          >=1.2.3.0  && <2.1
 
   -- other dependencies
   build-depends:
       servant-multipart-api == 0.12.*
-    , lens                >=4.17     && <5.1
+    , lens                >=4.17     && <5.2
     , resourcet           >=1.2.2    && <1.3
     , servant             >=0.16     && <0.20
     , servant-docs        >=0.10     && <0.20


### PR DESCRIPTION
Tested using

    cabal test --constraint='text>=2' --constraint='lens>=5.1' -w ghc-9.0.2 all

~~The allow-newers above can be removed when haskell-servant/servant/pull/1526 is released.~~