### PR TITLE
Haddock corrections

### DIFF
--- a/servant-multipart-api/src/Servant/Multipart/API.hs
+++ b/servant-multipart-api/src/Servant/Multipart/API.hs
@@ -110,7 +110,7 @@ import qualified Data.ByteString.Lazy as LBS
 --   @
 --
 --   Note that the behavior of this combinator is configurable,
---   by using 'serveWith' from servant-server instead of 'serve',
+--   by using 'serveWithContext' from servant-server instead of 'serve',
 --   which takes an additional 'Context' argument. It simply is an
 --   heterogeneous list where you can for example store
 --   a value of type 'MultipartOptions' that has the configuration that

--- a/servant-multipart-api/src/Servant/Multipart/API.hs
+++ b/servant-multipart-api/src/Servant/Multipart/API.hs
@@ -116,7 +116,7 @@ import qualified Data.ByteString.Lazy as LBS
 --   a value of type 'MultipartOptions' that has the configuration that
 --   you want, which would then get picked up by servant-multipart.
 --
---   __Important__: as mentionned in the example above,
+--   __Important__: as mentioned in the example above,
 --   the file paths point to temporary files which get removed
 --   after your handler has run, if they are still there. It is
 --   therefore recommended to move or copy them somewhere in your
@@ -208,7 +208,7 @@ instance FromMultipart tag (MultipartData tag) where
 --   @
 --   data User = User { username :: Text, pic :: FilePath }
 --
---   instance toMultipart Tmp User where
+--   instance ToMultipart Tmp User where
 --       toMultipart user = MultipartData [Input "username" $ username user]
 --                                        [FileData "pic"
 --                                                  (pic user)


### PR DESCRIPTION
Thank you for working on this package. Here's a fix of two typos in the docs.
EDIT: Actually noticed one more mistake in docs - they reference serveWith function in servant-server, which doesn't exist - there's only serveWithContext: https://hackage.haskell.org/package/servant-server-0.19.1/docs/doc-index-All.html