### PR TITLE
Export LookupContext from Servant.Multipart

### DIFF
--- a/servant-multipart/src/Servant/Multipart.hs
+++ b/servant-multipart/src/Servant/Multipart.hs
@@ -23,6 +23,7 @@ module Servant.Multipart
   , FromMultipart(..)
   , lookupInput
   , lookupFile
+  , LookupContext(..)
   , MultipartOptions(..)
   , defaultMultipartOptions
   , MultipartBackend(..)


### PR DESCRIPTION
I'm trying to use `hoistServerWithContext` with an API type that uses `MultipartForm`, and it seems to require explicitly specifying the `LookupContext` constraint on the context.

If there's objections to making `LookupContext` part of the public/stable API of this library, I'd be happy to instead submit an updated version of #40.