### PR TITLE
Allow transformers-0.6

### DIFF
--- a/servant-multipart-api/servant-multipart-api.cabal
+++ b/servant-multipart-api/servant-multipart-api.cabal
@@ -32,7 +32,7 @@ library
       base          >=4.9      && <5
     , bytestring    >=0.10.8.1 && <0.12
     , text          >=1.2.3.0  && <2.1
-    , transformers  >=0.5.2.0  && <0.6
+    , transformers  >=0.5.2.0  && <0.7
 
   -- other dependencies
   build-depends:


### PR DESCRIPTION
Tested with `cabal test -w ghc-9.2.7 all -c 'transformers>=0.6'`

and the following addition to `cabal.project`:

```
source-repository-package
    type: git
    location: https://github.com/haskell-servant/servant.git
    tag: ed07f5ac6c7535089426482e1c5a842cf28544e8
    subdir: servant-server
            servant
            servant-client-core
            servant-client
            servant-foreign
```
