### PR TITLE
Support servant-0.20 and add ghc-9.4 in CI

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.16
+# version: 0.17.20230826
 #
-# REGENDATA ("0.16",["github","cabal.project","--allow-failures",">= 9.2","--distribution","focal"])
+# REGENDATA ("0.17.20230826",["github","cabal.project","--allow-failures",">= 9.2","--distribution","focal"])
 #
 name: Haskell-CI
 on:
@@ -32,9 +32,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.2.7
+          - compiler: ghc-9.4.7
             compilerKind: ghc
-            compilerVersion: 9.2.7
+            compilerVersion: 9.4.7
+            setup-method: ghcup
+            allow-failure: true
+          - compiler: ghc-9.2.8
+            compilerKind: ghc
+            compilerVersion: 9.2.8
             setup-method: ghcup
             allow-failure: true
           - compiler: ghc-9.0.2
@@ -65,7 +70,7 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
@@ -74,7 +79,7 @@ jobs:
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
@@ -90,10 +95,12 @@ jobs:
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
           HCDIR=/opt/$HCKIND/$HCVER
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
+            HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+            HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+            HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
             echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
+            echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
             echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
@@ -243,16 +250,28 @@ jobs:
       - name: prepare for constraint sets
         run: |
           rm -f cabal.project.local
+      - name: constraint set servant-0.20
+        run: |
+          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='servant ==0.20.*' all --dry-run
+          cabal-plan topo | sort
+          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='servant ==0.20.*' --dependencies-only -j2 all
+          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='servant ==0.20.*' all
       - name: constraint set servant-0.19
         run: |
+          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='servant ==0.19.*' all --dry-run
+          cabal-plan topo | sort
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='servant ==0.19.*' --dependencies-only -j2 all
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='servant ==0.19.*' all
       - name: constraint set servant-0.18
         run: |
+          if [ $((HCNUMVER < 90200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='servant ==0.18.*' all --dry-run ; fi
+          if [ $((HCNUMVER < 90200)) -ne 0 ] ; then cabal-plan topo | sort ; fi
           if [ $((HCNUMVER < 90200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='servant ==0.18.*' --dependencies-only -j2 all ; fi
           if [ $((HCNUMVER < 90200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='servant ==0.18.*' all ; fi
       - name: constraint set servant-0.17
         run: |
+          if [ $((HCNUMVER < 81000)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='servant ==0.17.*' all --dry-run ; fi
+          if [ $((HCNUMVER < 81000)) -ne 0 ] ; then cabal-plan topo | sort ; fi
           if [ $((HCNUMVER < 81000)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='servant ==0.17.*' --dependencies-only -j2 all ; fi
           if [ $((HCNUMVER < 81000)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='servant ==0.17.*' all ; fi
       - name: save cache

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -9,5 +9,9 @@ constraint-set servant-0.18
   constraints: servant ==0.18.*
 
 constraint-set servant-0.19
-  ghc: >= 8.0 && <9.4
+  ghc: >= 8.6 && <9.6
   constraints: servant ==0.19.*
+
+constraint-set servant-0.20
+  ghc: >= 8.6 && <9.8
+  constraints: servant ==0.20.*

--- a/servant-multipart-api/servant-multipart-api.cabal
+++ b/servant-multipart-api/servant-multipart-api.cabal
@@ -20,7 +20,8 @@ tested-with:
    || ==8.8.4
    || ==8.10.7
    || ==9.0.2
-   || ==9.2.7
+   || ==9.2.8
+   || ==9.4.7
 
 library
   default-language: Haskell2010

--- a/servant-multipart-api/servant-multipart-api.cabal
+++ b/servant-multipart-api/servant-multipart-api.cabal
@@ -36,7 +36,7 @@ library
 
   -- other dependencies
   build-depends:
-      servant             >=0.16     && <0.20
+      servant             >=0.16     && <0.21
 
   -- servant-0.19 dropped support for GHC-8.4 (latest GHCJS version),
   -- due to QuantifiedConstraints

--- a/servant-multipart-client/servant-multipart-client.cabal
+++ b/servant-multipart-client/servant-multipart-client.cabal
@@ -19,7 +19,8 @@ tested-with:
    || ==8.8.4
    || ==8.10.7
    || ==9.0.2
-   || ==9.2.7
+   || ==9.2.8
+   || ==9.4.7
 
 library
   default-language: Haskell2010

--- a/servant-multipart-client/servant-multipart-client.cabal
+++ b/servant-multipart-client/servant-multipart-client.cabal
@@ -30,7 +30,6 @@ library
   build-depends:
       array         >=0.5.1.1  && <0.6
     , base          >=4.9      && <5
-    , base-compat   >=0.11.2   && <0.14
     , bytestring    >=0.10.8.1 && <0.12
     , text          >=1.2.3.0  && <2.1
     , random        >=0.1.1    && <1.3

--- a/servant-multipart-client/servant-multipart-client.cabal
+++ b/servant-multipart-client/servant-multipart-client.cabal
@@ -30,6 +30,7 @@ library
   build-depends:
       array         >=0.5.1.1  && <0.6
     , base          >=4.9      && <5
+    , base-compat   >=0.11.2   && <0.14
     , bytestring    >=0.10.8.1 && <0.12
     , text          >=1.2.3.0  && <2.1
     , random        >=0.1.1    && <1.3

--- a/servant-multipart-client/servant-multipart-client.cabal
+++ b/servant-multipart-client/servant-multipart-client.cabal
@@ -38,8 +38,8 @@ library
   build-depends:
       servant-multipart-api == 0.12.*
     , http-media          >=0.7.1.3  && <0.9
-    , servant             >=0.16     && <0.20
-    , servant-client-core >=0.16     && <0.20
+    , servant             >=0.16     && <0.21
+    , servant-client-core >=0.16     && <0.21
 
   -- servant-0.19 dropped support for GHC-8.4 (latest GHCJS version),
   -- due to QuantifiedConstraints

--- a/servant-multipart-client/src/Servant/Multipart/Client.hs
+++ b/servant-multipart-client/src/Servant/Multipart/Client.hs
@@ -27,7 +27,6 @@ import Servant.Multipart.API
 import Control.Monad (replicateM)
 import Data.Array (listArray, (!))
 import Data.List (foldl')
-import Data.List.Compat (singleton)
 #if !MIN_VERSION_base(4,11,0)
 import Data.Monoid ((<>))
 #endif
@@ -75,7 +74,7 @@ instance MultipartClient Tmp where
         readHandle hdl = fromActionStep LBS.null (LBS.hGet hdl 4096)
 
 instance MultipartClient Mem where
-    loadFile _ = source . singleton
+    loadFile _ = source . pure @[]
 
 -- | Generates a boundary to be used to separate parts of the multipart.
 -- Requires 'IO' because it is randomized.
@@ -133,7 +132,7 @@ multipartToBody boundary mp = RequestBodySource $ files' <> source ["--", bounda
     renderInput input = renderPart (lencode . iName $ input)
                                    "text/plain"
                                    ""
-                                   (source . singleton . lencode . iValue $ input)
+                                   (source . pure @[] . lencode . iValue $ input)
     inputs' = foldl' (\acc x -> acc `mappend'` renderInput x) mempty' (inputs mp)
     renderFile :: FileData tag -> SourceIO LBS.ByteString
     renderFile file = renderPart (lencode . fdInputName $ file)

--- a/servant-multipart-client/src/Servant/Multipart/Client.hs
+++ b/servant-multipart-client/src/Servant/Multipart/Client.hs
@@ -27,6 +27,7 @@ import Servant.Multipart.API
 import Control.Monad (replicateM)
 import Data.Array (listArray, (!))
 import Data.List (foldl')
+import Data.List.Compat (singleton)
 #if !MIN_VERSION_base(4,11,0)
 import Data.Monoid ((<>))
 #endif
@@ -74,7 +75,7 @@ instance MultipartClient Tmp where
         readHandle hdl = fromActionStep LBS.null (LBS.hGet hdl 4096)
 
 instance MultipartClient Mem where
-    loadFile _ = source . pure
+    loadFile _ = source . singleton
 
 -- | Generates a boundary to be used to separate parts of the multipart.
 -- Requires 'IO' because it is randomized.
@@ -132,7 +133,7 @@ multipartToBody boundary mp = RequestBodySource $ files' <> source ["--", bounda
     renderInput input = renderPart (lencode . iName $ input)
                                    "text/plain"
                                    ""
-                                   (source . pure . lencode . iValue $ input)
+                                   (source . singleton . lencode . iValue $ input)
     inputs' = foldl' (\acc x -> acc `mappend'` renderInput x) mempty' (inputs mp)
     renderFile :: FileData tag -> SourceIO LBS.ByteString
     renderFile file = renderPart (lencode . fdInputName $ file)

--- a/servant-multipart/servant-multipart.cabal
+++ b/servant-multipart/servant-multipart.cabal
@@ -19,7 +19,8 @@ tested-with:
      || ==8.8.4
      || ==8.10.7
      || ==9.0.2
-     || ==9.2.7
+     || ==9.2.8
+     || ==9.4.7
 
 library
   default-language: Haskell2010
@@ -37,10 +38,10 @@ library
   build-depends:
       servant-multipart-api == 0.12.*
     , lens                >=4.17     && <5.3
-    , resourcet           >=1.2.2    && <1.3
+    , resourcet           >=1.2.2    && <1.4
     , servant             >=0.16     && <0.21
-    , servant-docs        >=0.10     && <0.20
-    , servant-foreign     >=0.15     && <0.20
+    , servant-docs        >=0.10     && <0.14
+    , servant-foreign     >=0.15     && <0.17
     , servant-server      >=0.16     && <0.21
     , string-conversions  >=0.4.0.1  && <0.5
     , wai                 >=3.2.1.2  && <3.3

--- a/servant-multipart/servant-multipart.cabal
+++ b/servant-multipart/servant-multipart.cabal
@@ -38,10 +38,10 @@ library
       servant-multipart-api == 0.12.*
     , lens                >=4.17     && <5.3
     , resourcet           >=1.2.2    && <1.3
-    , servant             >=0.16     && <0.20
+    , servant             >=0.16     && <0.21
     , servant-docs        >=0.10     && <0.20
     , servant-foreign     >=0.15     && <0.20
-    , servant-server      >=0.16     && <0.20
+    , servant-server      >=0.16     && <0.21
     , string-conversions  >=0.4.0.1  && <0.5
     , wai                 >=3.2.1.2  && <3.3
     , wai-extra           >=3.0.24.3 && <3.2


### PR DESCRIPTION
This PR proposes to:
- Bump servant to v0.20
- Bump GHC versions in CI, using the current `master` version of `haskell-ci`, ie: https://github.com/haskell-CI/haskell-ci/commit/8a71bd5d1930c8e6515e15648e92bde53078cd5e
- Review some package dependencies