### PR TITLE
Bounds bumps: `network ^>=3.2`, `lens ^>=5.3`

### DIFF
--- a/servant-multipart-client/servant-multipart-client.cabal
+++ b/servant-multipart-client/servant-multipart-client.cabal
@@ -58,7 +58,7 @@ executable upload
   build-depends:
       base
     , http-client
-    , network            >=2.8 && <3.2
+    , network            >=2.8 && <3.3
     , servant
     , servant-multipart-api
     , servant-multipart-client
@@ -72,7 +72,7 @@ executable server
   build-depends:
       base
     , bytestring
-    , network            >=2.8 && <3.2
+    , network            >=2.8 && <3.3
     , servant-multipart
     , servant-server
     , warp

--- a/servant-multipart/servant-multipart.cabal
+++ b/servant-multipart/servant-multipart.cabal
@@ -39,7 +39,7 @@ library
   -- other dependencies
   build-depends:
       servant-multipart-api == 0.12.*
-    , lens                >=4.17     && <5.3
+    , lens                >=4.17     && <5.4
     , resourcet           >=1.2.2    && <1.4
     , servant             >=0.16     && <0.21
     , servant-docs        >=0.10     && <0.14


### PR DESCRIPTION
This PR passed `cabal test all --constraint 'lens ^>=5.3' --constraint 'network ^>=3.2' --allow-newer=servant-server:network --allow-newer=servant-foreign:lens --allow-newer=servant-docs:lens`.

The main servant repo depends on some packages in this repo, and vice versa. So there's no good place to start bounds bumps.

Also, can we please have Hackage metadata revisions when this is merged?