### PR TITLE
Allow network-3.2, lens-5.3

### DIFF
--- a/servant-multipart-client/servant-multipart-client.cabal
+++ b/servant-multipart-client/servant-multipart-client.cabal
@@ -58,7 +58,7 @@ executable upload
   build-depends:
       base
     , http-client
-    , network            >=2.8 && <3.2
+    , network            >=2.8 && <3.3
     , servant
     , servant-multipart-api
     , servant-multipart-client
@@ -72,7 +72,7 @@ executable server
   build-depends:
       base
     , bytestring
-    , network            >=2.8 && <3.2
+    , network            >=2.8 && <3.3
     , servant-multipart
     , servant-server
     , warp

--- a/servant-multipart/servant-multipart.cabal
+++ b/servant-multipart/servant-multipart.cabal
@@ -39,7 +39,7 @@ library
   -- other dependencies
   build-depends:
       servant-multipart-api == 0.12.*
-    , lens                >=4.17     && <5.3
+    , lens                >=4.17     && <5.4
     , resourcet           >=1.2.2    && <1.4
     , servant             >=0.16     && <0.21
     , servant-docs        >=0.10     && <0.14


### PR DESCRIPTION
Tested using

    cabal build all -c 'network>=3.2' -c 'lens>=5.3' -w ghc-9.8.2 --allow-newer=servant-foreign:lens,servant-docs:lens  -c 'servant-client-core<0.20.1'

Avoiding client-core-0.20.1 because of https://github.com/haskell-servant/servant/issues/1758
