### PR TITLE
Expose `LookupContext` and `MultipartClient`

### DIFF
--- a/servant-multipart-client/src/Servant/Multipart/Client.hs
+++ b/servant-multipart-client/src/Servant/Multipart/Client.hs
@@ -20,6 +20,7 @@ module Servant.Multipart.Client
   ( genBoundary
   , ToMultipart(..)
   , multipartToBody
+  , MultipartClient(..)
   ) where
 
 import Servant.Multipart.API

--- a/servant-multipart/src/Servant/Multipart.hs
+++ b/servant-multipart/src/Servant/Multipart.hs
@@ -34,6 +34,7 @@ module Servant.Multipart
   , FileData(..)
   -- * servant-docs
   , ToMultipartSample(..)
+  , LookupContext(..)
   ) where
 
 import Servant.Multipart.API


### PR DESCRIPTION
This extends the PR here [here](https://github.com/haskell-servant/servant-multipart/pull/63) in that it also exposes the `MultipartClient` class from [`servant-multipart-client`](https://hackage.haskell.org/package/servant-multipart-client-0.12.2).

I'm writing a library `servant-miso-multipart-client` than needs to interact with [`servant-miso-client`](https://github.com/haskell-miso/servant-miso-client) and [`servant-multipart-client`](https://hackage.haskell.org/package/servant-multipart-client-0.12.2). So I need to write new instances both on the server and client side.

To do this I need to write new `MultipartClient` instances directly and I need  `LookupContext` exposed so I can refer to it in the constraints of new [`HasServer`](https://hackage-content.haskell.org/package/servant-server-0.20.3.0/docs/Servant-Server.html#t:HasServer) instances.
