### PR TITLE
Move `lookupInput` and `lookupFile` from `servant-multipart` to `servant-multipart-api`

### DIFF
--- a/servant-multipart-api/servant-multipart-api.cabal
+++ b/servant-multipart-api/servant-multipart-api.cabal
@@ -40,6 +40,7 @@ library
   -- other dependencies
   build-depends:
       servant             >=0.16     && <0.21
+    , string-conversions  >=0.4.0.1  && <0.5
 
   -- servant-0.19 dropped support for GHC-8.4 (latest GHCJS version),
   -- due to QuantifiedConstraints

--- a/servant-multipart-api/src/Servant/Multipart/API.hs
+++ b/servant-multipart-api/src/Servant/Multipart/API.hs
@@ -31,9 +31,13 @@ module Servant.Multipart.API
   , Mem
   , Input(..)
   , FileData(..)
+  , lookupInput
+  , lookupFile
   ) where
 
+import Data.List (find)
 import Data.Text (Text)
+import Data.String.Conversions (cs)
 import Data.Typeable
 import Servant.API
 
@@ -146,6 +150,20 @@ data MultipartData tag = MultipartData
   { inputs :: [Input]
   , files  :: [FileData tag]
   }
+
+-- | Lookup a textual input with the given @name@ attribute.
+lookupInput :: Text -> MultipartData tag -> Either String Text
+lookupInput iname =
+  maybe (Left $ "Field " <> cs iname <> " not found") (Right . iValue)
+  . find ((==iname) . iName)
+  . inputs
+
+-- | Lookup a file input with the given @name@ attribute.
+lookupFile :: Text -> MultipartData tag -> Either String (FileData tag)
+lookupFile iname =
+  maybe (Left $ "File " <> cs iname <> " not found") Right
+  . find ((==iname) . fdInputName)
+  . files
 
 -- | Representation for an uploaded file, usually resulting from
 --   picking a local file for an HTML input that looks like

--- a/servant-multipart/src/Servant/Multipart.hs
+++ b/servant-multipart/src/Servant/Multipart.hs
@@ -41,7 +41,6 @@ import Servant.Multipart.API
 import Control.Lens ((<>~), (&), view, (.~))
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Resource
-import Data.List (find)
 import Data.Maybe
 #if !MIN_VERSION_base(4,11,0)
 import Data.Monoid ((<>))
@@ -60,20 +59,6 @@ import Servant.Server.Internal
 import System.Directory
 
 import qualified Data.ByteString      as SBS
-
--- | Lookup a textual input with the given @name@ attribute.
-lookupInput :: Text -> MultipartData tag -> Either String Text
-lookupInput iname =
-  maybe (Left $ "Field " <> cs iname <> " not found") (Right . iValue)
-  . find ((==iname) . iName)
-  . inputs
-
--- | Lookup a file input with the given @name@ attribute.
-lookupFile :: Text -> MultipartData tag -> Either String (FileData tag)
-lookupFile iname =
-  maybe (Left $ "File " <> cs iname <> " not found") Right
-  . find ((==iname) . fdInputName)
-  . files
 
 fromRaw :: forall tag. ([Network.Wai.Parse.Param], [File (MultipartResult tag)])
         -> MultipartData tag


### PR DESCRIPTION
This adds one extra dependency to `servant-multipart-api`, namely `string-conversions`, but this library is small and it's dependencies are already dependencies of `servant-multipart-api` anyway.

It means that downstream libraries that call these functions don't have to transitively depend on `servant-server`, which itself has many dependencies, a number of which are not able to be built under WASM (such as `network`).

It's similar in motivation to [this PR to servant](https://github.com/haskell-servant/servant/pull/1911).

(I've now noticed these functions are actually pretty easy to reimplement and are only used by tests, so this isn't actually a big deal in hindsight). 
